### PR TITLE
Mirror custom CSS classes onto table tag

### DIFF
--- a/blocks/msv_table/templates/first_row_header.php
+++ b/blocks/msv_table/templates/first_row_header.php
@@ -43,7 +43,13 @@ if (!empty($table_data)): ?>
 		if (empty($data)) {
 			$table = '';
 		} else {
-			$table = '<table class="table table-bordered">';
+			$custom_css_class = '';
+			$b = Block::getByID($bID, Page::getCurrentPage(), $this->block->getAreaHandle());
+			if ($b && $b->getCustomStyle() && $b->getCustomStyle()->getStyleSet()) {
+				$custom_css_class = $b->getCustomStyle()->getStyleSet()->getCustomClass();
+			}
+
+			$table = '<table class="table ' . $custom_css_class . ' ">';
 
 			if ($header) {
 				$table .= '<thead>';

--- a/blocks/msv_table/templates/no_headers.php
+++ b/blocks/msv_table/templates/no_headers.php
@@ -43,7 +43,13 @@ if (!empty($table_data)): ?>
         if (empty($data)) {
             $table = '';
         } else {
-            $table = '<table class="table table-bordered">';
+            $custom_css_class = '';
+            $b = Block::getByID($bID, Page::getCurrentPage(), $this->block->getAreaHandle());
+            if ($b && $b->getCustomStyle() && $b->getCustomStyle()->getStyleSet()) {
+                $custom_css_class = $b->getCustomStyle()->getStyleSet()->getCustomClass();
+            }
+
+            $table = '<table class="table ' . $custom_css_class . ' ">';
 
             if ($header) {
                 $table .= '<thead>';

--- a/blocks/msv_table/view.php
+++ b/blocks/msv_table/view.php
@@ -43,7 +43,13 @@ if (!empty($table_data)): ?>
 		if (empty($data)) {
 			$table = '';
 		} else {
-			$table = '<table class="table table-bordered">';
+			$custom_css_class = '';
+			$b = Block::getByID($bID, Page::getCurrentPage(), $this->block->getAreaHandle());
+			if ($b && $b->getCustomStyle() && $b->getCustomStyle()->getStyleSet()) {
+				$custom_css_class = $b->getCustomStyle()->getStyleSet()->getCustomClass();
+			}
+
+			$table = '<table class="table ' . $custom_css_class . ' ">';
 
 			if ($header) {
 				$table .= '<thead>';


### PR DESCRIPTION
We wanted to be able to apply the Bootstrap table classes to the table itself via the block's [Custom Class control](http://www.concrete5.org/documentation/developers/5.7/designing-for-concrete5/advanced-css-and-javascript-usage/adding-custom-css-classes-to-blocks-areas-and-the-editor/), so we came up with this.

We also added this function to our theme (in page_theme.php) so that our users would be able to apply the classes more easily:

```
public function getThemeBlockClasses()
{
    return array(
        'msv_table' => array(
            'table-striped',
            'table-bordered',
            'table-consdensed',
            'table-responsive',
        ),
    );
}
```

Thoughts?
